### PR TITLE
[Feat] AI 창식이 — 응답 내 숙소·동행 링크 카드 클릭 기능

### DIFF
--- a/finalProject/fronted/src/components/ai/AiChatPanel.jsx
+++ b/finalProject/fronted/src/components/ai/AiChatPanel.jsx
@@ -2,8 +2,9 @@
  * AI 창식이 채팅 슬라이드 패널 컴포넌트 - 실시간 대화 UI, 빠른 질문, 타이핑 인디케이터
  */
 import React, { useState, useRef, useEffect } from 'react';
-import { X, Send, RotateCcw, AlertCircle, Palmtree, MapPin, UtensilsCrossed, Compass, Plane } from 'lucide-react';
+import { X, Send, RotateCcw, AlertCircle, Palmtree, MapPin, UtensilsCrossed, Compass, Plane, ExternalLink } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
+import { useNavigate } from 'react-router-dom';
 import { useSendAiChat } from '../../api/ai/useAiChat';
 import changsikImg from '../../assets/images/page/제주.png';
 
@@ -19,11 +20,36 @@ const WELCOME_MESSAGE = {
   content: '혼저옵서예~ 🍊\n저는 제주 여행 AI 도우미 창식이예요!\n\n관광지, 맛집, 숙소, 항공편, 교통 등\n제주에 대해 궁금한 거 뭐든 물어보세요!',
 };
 
-/** 마크다운 **bold** 를 <strong> 태그로 변환하여 렌더링 */
-function renderMarkdown(text) {
+/** 숙소/동행 링크 타입 판별 */
+function getLinkMeta(href) {
+  if (href.startsWith('/accommodations/')) {
+    return { type: 'accommodation', label: '숙소 보기', color: 'bg-sky-50 text-sky-600 border-sky-200 hover:bg-sky-100' };
+  }
+  if (href.startsWith('/companions/')) {
+    return { type: 'companion', label: '동행 보기', color: 'bg-emerald-50 text-emerald-600 border-emerald-200 hover:bg-emerald-100' };
+  }
+  return null;
+}
+
+/** 마크다운 **bold**, [text](url) 링크 파싱 후 렌더링 */
+function renderMarkdown(text, navigate) {
   if (!text) return null;
 
-  return text.split('\n').map((line, li) => {
+  // [text](url) 링크 → 클릭 가능한 카드 버튼으로 추출 (줄 단위 처리 전)
+  const linkCards = [];
+  const LINK_RE = /\[([^\]]+)\]\((\/[^)]+)\)/g;
+  let match;
+  while ((match = LINK_RE.exec(text)) !== null) {
+    const meta = getLinkMeta(match[2]);
+    if (meta) {
+      linkCards.push({ label: match[1], href: match[2], meta });
+    }
+  }
+
+  // 링크 마크다운 제거 후 텍스트만 남김
+  const cleanText = text.replace(/\[([^\]]+)\]\(\/[^)]+\)/g, '$1');
+
+  const lines = cleanText.split('\n').map((line, li) => {
     const parts = [];
     let rest = line;
     let k = 0;
@@ -33,7 +59,6 @@ function renderMarkdown(text) {
       if (s === -1) { parts.push(rest); break; }
       const e = rest.indexOf('**', s + 2);
       if (e === -1) { parts.push(rest); break; }
-
       if (s > 0) parts.push(rest.substring(0, s));
       parts.push(
         <strong key={k++} className="font-semibold">
@@ -50,6 +75,26 @@ function renderMarkdown(text) {
       </React.Fragment>
     );
   });
+
+  return (
+    <>
+      {lines}
+      {linkCards.length > 0 && (
+        <div className="flex flex-col gap-1.5 mt-2.5">
+          {linkCards.map((card, i) => (
+            <button
+              key={i}
+              onClick={() => navigate(card.href)}
+              className={`flex items-center justify-between gap-2 px-3 py-2 rounded-xl border text-[12px] font-semibold transition-colors ${card.meta.color}`}
+            >
+              <span className="truncate text-left">{card.label}</span>
+              <ExternalLink className="w-3 h-3 flex-shrink-0 opacity-60" />
+            </button>
+          ))}
+        </div>
+      )}
+    </>
+  );
 }
 
 const STORAGE_KEY = 'changsik_chat_history';
@@ -68,6 +113,7 @@ function loadMessages() {
 }
 
 export default function AiChatPanel({ isOpen, onClose, motionX, motionY }) {
+  const navigate = useNavigate();
   const [messages, setMessages] = useState(loadMessages);
   const [inputValue, setInputValue] = useState('');
   const [error, setError] = useState(null);
@@ -217,7 +263,7 @@ export default function AiChatPanel({ isOpen, onClose, motionX, motionY }) {
                     : 'bg-white text-gray-700 rounded-2xl rounded-bl-md shadow-[0_1px_2px_rgba(0,0,0,0.06)]'
                 }`}
               >
-                {renderMarkdown(msg.content)}
+                {renderMarkdown(msg.content, navigate)}
               </div>
             </motion.div>
           ))}


### PR DESCRIPTION
## 📌 개요
AI 창식이가 숙소나 동행 모집을 언급할 때, 텍스트 대신 **클릭 가능한 링크 카드**로 표시되도록 개선했습니다.
사용자가 AI 응답을 보면서 바로 해당 페이지로 이동할 수 있습니다.

## ✅ 변경 파일

### 백엔드
- `ai-context-mapper.xml`
  - `selectAccommodationSummary`: `ACCOMMODATION_NO` 컬럼 추가
  - `selectRecentCompanionSummary`: `COMPANION_NO` 컬럼 추가

- `AiChatService.java`
  - 시스템 프롬프트에 **링크 형식 규칙** 추가
    - 숙소 언급 시: `[숙소명](/accommodations/숙소번호)` 형식 출력 지시
    - 동행 언급 시: `[동행제목](/companions/동행번호)` 형식 출력 지시
  - `appendAccommodationContext()`: 컨텍스트에 ID 포함한 마크다운 링크 형식으로 변경
  - `appendCompanionContext()`: 동일하게 ID 포함 링크 형식 적용

### 프론트엔드
- `AiChatPanel.jsx`
  - `useNavigate` 추가
  - `renderMarkdown()` 함수 확장:
    - `[text](/path)` 패턴을 정규식으로 파싱
    - 숙소(`/accommodations/`) → 하늘색 카드 버튼
    - 동행(`/companions/`) → 초록색 카드 버튼
    - 링크 마크다운은 텍스트에서 제거 후 카드로만 표시
    - 카드 클릭 시 해당 페이지로 `navigate()` 이동

## 🔍 동작 흐름

```
1. 사용자: "HONDI에 숙소 추천해줘"
2. AI: "한림 게스트하우스 [한림 게스트하우스](/accommodations/3) 를 추천드려요!"
3. 프론트: 링크 파싱 → 하늘색 카드 버튼 렌더링
4. 사용자 클릭 → /accommodations/3 으로 이동
```

## 🎨 UI 상세
| 타입 | 색상 | 아이콘 |
|------|------|--------|
| 숙소 | 하늘색 (sky) | ExternalLink |
| 동행 | 초록색 (emerald) | ExternalLink |

## 🖥️ 테스트
- [x] 로컬 빌드 오류 없음
- [x] 프로덕션 배포 (https://hondi.site) 완료
- [ ] 백엔드 재배포 후 AI 링크 카드 동작 확인 필요