### PR TITLE
[Perf] 성능 최적화: 쿼리 LEFT JOIN 변환, 캐시 강화, 빌드 최적화

### DIFF
--- a/finalProject/backend/src/main/java/edu/kh/project/common/config/CacheConfig.java
+++ b/finalProject/backend/src/main/java/edu/kh/project/common/config/CacheConfig.java
@@ -16,10 +16,16 @@ public class CacheConfig {
 
     @Bean
     public CacheManager cacheManager() {
-        CaffeineCacheManager manager = new CaffeineCacheManager("dashboardStats", "activeSpots");
+        CaffeineCacheManager manager = new CaffeineCacheManager(
+                "dashboardStats", "activeSpots", "memberStats"
+        );
         manager.setCaffeine(Caffeine.newBuilder()
-                .expireAfterWrite(5, TimeUnit.MINUTES)
-                .maximumSize(100));
+                .expireAfterAccess(10, TimeUnit.MINUTES)
+                .maximumSize(500));
         return manager;
     }
 }
+
+
+
+

--- a/finalProject/backend/src/main/java/edu/kh/project/member/service/MemberServiceImpl.java
+++ b/finalProject/backend/src/main/java/edu/kh/project/member/service/MemberServiceImpl.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -42,6 +43,7 @@ public class MemberServiceImpl implements MemberService {
      * 이메일 중복 확인
      */
     @Override
+    @Transactional(readOnly = true)
     public int checkEmail(String memberEmail) {
         return memberMapper.checkEmailDuplicate(memberEmail);
     }
@@ -50,6 +52,7 @@ public class MemberServiceImpl implements MemberService {
      * 닉네임 중복 확인 (memberNo 전달 시 본인 제외)
      */
     @Override
+    @Transactional(readOnly = true)
     public int checkNickname(String memberNickname, Integer memberNo) {
         return memberMapper.checkNicknameDuplicate(memberNickname, memberNo);
     }
@@ -134,6 +137,7 @@ public class MemberServiceImpl implements MemberService {
      * 회원 번호로 회원 조회 (경량 — 통계 미포함)
      */
     @Override
+    @Transactional(readOnly = true)
     public MemberDTO getMemberByNo(int memberNo) {
         return memberMapper.selectMemberByNo(memberNo);
     }
@@ -142,6 +146,7 @@ public class MemberServiceImpl implements MemberService {
      * 회원 번호로 회원 조회 (통계 포함 — 프로필 페이지용)
      */
     @Override
+    @Cacheable(value = "memberStats", key = "#memberNo")
     @Transactional(readOnly = true)
     public MemberDTO getMemberWithStats(int memberNo) {
         return memberMapper.selectMemberWithStats(memberNo);
@@ -160,6 +165,7 @@ public class MemberServiceImpl implements MemberService {
      * 아이디 찾기 (이름 + 이메일)
      */
     @Override
+    @Transactional(readOnly = true)
     public MemberDTO findId(String memberName, String memberEmail) {
         return memberMapper.findId(memberName, memberEmail);
     }
@@ -168,6 +174,7 @@ public class MemberServiceImpl implements MemberService {
      * 비밀번호 찾기
      */
     @Override
+    @Transactional(readOnly = true)
     public MemberDTO findPw(String memberEmail, String memberName, String memberEmail2) {
         
         // 이메일 일치 확인

--- a/finalProject/backend/src/main/java/edu/kh/project/spot/service/SpotServiceImpl.java
+++ b/finalProject/backend/src/main/java/edu/kh/project/spot/service/SpotServiceImpl.java
@@ -44,6 +44,7 @@ public class SpotServiceImpl implements SpotService {
      * 전체 명소 목록 조회 (관리자용)
      */
     @Override
+    @Transactional(readOnly = true)
     public List<SpotDTO> getAllSpots() {
         return spotMapper.selectAllSpots();
     }
@@ -52,6 +53,7 @@ public class SpotServiceImpl implements SpotService {
      * 명소 상세 조회
      */
     @Override
+    @Transactional(readOnly = true)
     public SpotDTO getSpotByNo(int spotNo) {
         return spotMapper.selectSpotByNo(spotNo);
     }

--- a/finalProject/backend/src/main/resources/mappers/activity-mapper.xml
+++ b/finalProject/backend/src/main/resources/mappers/activity-mapper.xml
@@ -47,12 +47,24 @@
                 TO_CHAR(B.CREATED_AT, 'YYYY-MM-DD') AS CREATED_AT,
                 M.NICKNAME AS MEMBER_NICKNAME,
                 M.PROFILE_IMAGE AS MEMBER_PROFILE,
-                (SELECT COUNT(*) FROM COMMENT_TBL C WHERE C.BOARD_NO = B.BOARD_NO AND C.STATUS = 'A') AS COMMENT_COUNT,
-                (SELECT COUNT(*) FROM BOARD_LIKE BL WHERE BL.BOARD_NO = B.BOARD_NO) AS LIKE_COUNT,
-                (SELECT MIN(BI.IMAGE_URL) FROM BOARD_IMAGE BI WHERE BI.BOARD_NO = B.BOARD_NO AND BI.IMAGE_ORDER = 0) AS IMAGE_URLS,
+                NVL(cc.COMMENT_COUNT, 0) AS COMMENT_COUNT,
+                NVL(lc.LIKE_COUNT, 0)   AS LIKE_COUNT,
+                bi.IMAGE_URLS,
                 ROW_NUMBER() OVER (ORDER BY B.BOARD_NO DESC) AS RN
             FROM BOARD B
             JOIN MEMBER M ON B.MEMBER_NO = M.MEMBER_NO
+            LEFT JOIN (
+                SELECT BOARD_NO, COUNT(*) AS COMMENT_COUNT
+                FROM COMMENT_TBL WHERE STATUS = 'A' GROUP BY BOARD_NO
+            ) cc ON cc.BOARD_NO = B.BOARD_NO
+            LEFT JOIN (
+                SELECT BOARD_NO, COUNT(*) AS LIKE_COUNT
+                FROM BOARD_LIKE GROUP BY BOARD_NO
+            ) lc ON lc.BOARD_NO = B.BOARD_NO
+            LEFT JOIN (
+                SELECT BOARD_NO, MIN(IMAGE_URL) AS IMAGE_URLS
+                FROM BOARD_IMAGE WHERE IMAGE_ORDER = 0 GROUP BY BOARD_NO
+            ) bi ON bi.BOARD_NO = B.BOARD_NO
             WHERE B.BOARD_CODE = 'ACTIVITY'
               AND B.STATUS = 'A'
             <if test="search != null and search != ''">
@@ -88,18 +100,35 @@
             TO_CHAR(B.UPDATED_AT, 'YYYY-MM-DD HH24:MI') AS UPDATED_AT,
             M.NICKNAME AS MEMBER_NICKNAME,
             M.PROFILE_IMAGE AS MEMBER_PROFILE,
-            (SELECT COUNT(*) FROM COMMENT_TBL C WHERE C.BOARD_NO = B.BOARD_NO AND C.STATUS = 'A') AS COMMENT_COUNT,
-            (SELECT COUNT(*) FROM BOARD_LIKE BL WHERE BL.BOARD_NO = B.BOARD_NO) AS LIKE_COUNT,
+            NVL(cc.COMMENT_COUNT, 0) AS COMMENT_COUNT,
+            NVL(lc.LIKE_COUNT, 0)   AS LIKE_COUNT,
             <if test="memberNo != 0">
-                (SELECT COUNT(*) FROM BOARD_LIKE BL WHERE BL.BOARD_NO = B.BOARD_NO AND BL.MEMBER_NO = #{memberNo}) AS IS_LIKED,
+                NVL(ml.IS_LIKED, 0) AS IS_LIKED,
             </if>
             <if test="memberNo == 0">
                 0 AS IS_LIKED,
             </if>
-            (SELECT LISTAGG(BI.IMAGE_URL, ',') WITHIN GROUP (ORDER BY BI.IMAGE_ORDER)
-             FROM BOARD_IMAGE BI WHERE BI.BOARD_NO = B.BOARD_NO) AS IMAGE_URLS
+            img.IMAGE_URLS
         FROM BOARD B
         JOIN MEMBER M ON B.MEMBER_NO = M.MEMBER_NO
+        LEFT JOIN (
+            SELECT BOARD_NO, COUNT(*) AS COMMENT_COUNT
+            FROM COMMENT_TBL WHERE STATUS = 'A' GROUP BY BOARD_NO
+        ) cc ON cc.BOARD_NO = B.BOARD_NO
+        LEFT JOIN (
+            SELECT BOARD_NO, COUNT(*) AS LIKE_COUNT
+            FROM BOARD_LIKE GROUP BY BOARD_NO
+        ) lc ON lc.BOARD_NO = B.BOARD_NO
+        <if test="memberNo != 0">
+        LEFT JOIN (
+            SELECT BOARD_NO, COUNT(*) AS IS_LIKED
+            FROM BOARD_LIKE WHERE MEMBER_NO = #{memberNo} GROUP BY BOARD_NO
+        ) ml ON ml.BOARD_NO = B.BOARD_NO
+        </if>
+        LEFT JOIN (
+            SELECT BOARD_NO, LISTAGG(IMAGE_URL, ',') WITHIN GROUP (ORDER BY IMAGE_ORDER) AS IMAGE_URLS
+            FROM BOARD_IMAGE GROUP BY BOARD_NO
+        ) img ON img.BOARD_NO = B.BOARD_NO
         WHERE B.BOARD_NO = #{boardNo}
           AND B.BOARD_CODE = 'ACTIVITY'
           AND B.STATUS = 'A'

--- a/finalProject/backend/src/main/resources/mappers/companion-mapper.xml
+++ b/finalProject/backend/src/main/resources/mappers/companion-mapper.xml
@@ -107,13 +107,15 @@
             M.NICKNAME AS AUTHOR_NICKNAME,
             M.PROFILE_IMAGE AS AUTHOR_PROFILE,
             M.AGE_RANGE AS AUTHOR_AGE_RANGE,
-            (SELECT COUNT(*)
-             FROM COMPANION_JOIN J
-             WHERE J.COMPANION_NO = C.COMPANION_NO
-               AND J.STATUS IN ('W', 'A')
-            ) AS CURRENT_MEMBERS
+            NVL(jc.CURRENT_MEMBERS, 0) AS CURRENT_MEMBERS
         FROM COMPANION_BOARD C
         JOIN MEMBER M ON C.MEMBER_NO = M.MEMBER_NO
+        LEFT JOIN (
+            SELECT COMPANION_NO, COUNT(*) AS CURRENT_MEMBERS
+            FROM COMPANION_JOIN
+            WHERE STATUS IN ('W', 'A')
+            GROUP BY COMPANION_NO
+        ) jc ON jc.COMPANION_NO = C.COMPANION_NO
         WHERE C.COMPANION_NO = #{companionNo}
           AND C.STATUS != 'N'
     </select>

--- a/finalProject/backend/src/main/resources/mappers/freeboard-mapper.xml
+++ b/finalProject/backend/src/main/resources/mappers/freeboard-mapper.xml
@@ -100,18 +100,35 @@
             TO_CHAR(B.UPDATED_AT, 'YYYY-MM-DD HH24:MI') AS UPDATED_AT,
             M.NICKNAME AS MEMBER_NICKNAME,
             M.PROFILE_IMAGE AS MEMBER_PROFILE,
-            (SELECT COUNT(*) FROM COMMENT_TBL C WHERE C.BOARD_NO = B.BOARD_NO AND C.STATUS = 'A') AS COMMENT_COUNT,
-            (SELECT COUNT(*) FROM BOARD_LIKE BL WHERE BL.BOARD_NO = B.BOARD_NO) AS LIKE_COUNT,
+            NVL(cc.COMMENT_COUNT, 0) AS COMMENT_COUNT,
+            NVL(lc.LIKE_COUNT, 0)   AS LIKE_COUNT,
             <if test="memberNo != 0">
-                (SELECT COUNT(*) FROM BOARD_LIKE BL WHERE BL.BOARD_NO = B.BOARD_NO AND BL.MEMBER_NO = #{memberNo}) AS IS_LIKED,
+                NVL(ml.IS_LIKED, 0) AS IS_LIKED,
             </if>
             <if test="memberNo == 0">
                 0 AS IS_LIKED,
             </if>
-            (SELECT LISTAGG(BI.IMAGE_URL, ',') WITHIN GROUP (ORDER BY BI.IMAGE_ORDER)
-             FROM BOARD_IMAGE BI WHERE BI.BOARD_NO = B.BOARD_NO) AS IMAGE_URLS
+            img.IMAGE_URLS
         FROM BOARD B
         JOIN MEMBER M ON B.MEMBER_NO = M.MEMBER_NO
+        LEFT JOIN (
+            SELECT BOARD_NO, COUNT(*) AS COMMENT_COUNT
+            FROM COMMENT_TBL WHERE STATUS = 'A' GROUP BY BOARD_NO
+        ) cc ON cc.BOARD_NO = B.BOARD_NO
+        LEFT JOIN (
+            SELECT BOARD_NO, COUNT(*) AS LIKE_COUNT
+            FROM BOARD_LIKE GROUP BY BOARD_NO
+        ) lc ON lc.BOARD_NO = B.BOARD_NO
+        <if test="memberNo != 0">
+        LEFT JOIN (
+            SELECT BOARD_NO, COUNT(*) AS IS_LIKED
+            FROM BOARD_LIKE WHERE MEMBER_NO = #{memberNo} GROUP BY BOARD_NO
+        ) ml ON ml.BOARD_NO = B.BOARD_NO
+        </if>
+        LEFT JOIN (
+            SELECT BOARD_NO, LISTAGG(IMAGE_URL, ',') WITHIN GROUP (ORDER BY IMAGE_ORDER) AS IMAGE_URLS
+            FROM BOARD_IMAGE GROUP BY BOARD_NO
+        ) img ON img.BOARD_NO = B.BOARD_NO
         WHERE B.BOARD_NO = #{boardNo}
           AND B.BOARD_CODE = 'FREE'
           AND B.STATUS = 'A'

--- a/finalProject/backend/src/main/resources/mappers/member-mapper.xml
+++ b/finalProject/backend/src/main/resources/mappers/member-mapper.xml
@@ -202,10 +202,16 @@
                 B.BOARD_NO AS "boardNo",
                 B.TITLE AS "title",
                 TO_CHAR(B.CREATED_AT, 'YYYY-MM-DD') AS "createdAt",
-                (SELECT COUNT(*) FROM COMMENT_TBL C WHERE C.BOARD_NO = B.BOARD_NO AND C.STATUS = 'A') AS "commentCount",
-                (SELECT COUNT(*) FROM BOARD_LIKE BL WHERE BL.BOARD_NO = B.BOARD_NO) AS "likeCount",
+                NVL(cc.CNT, 0) AS "commentCount",
+                NVL(lc.CNT, 0) AS "likeCount",
                 ROW_NUMBER() OVER (ORDER BY B.CREATED_AT DESC) AS RN
             FROM BOARD B
+            LEFT JOIN (
+                SELECT BOARD_NO, COUNT(*) AS CNT FROM COMMENT_TBL WHERE STATUS = 'A' GROUP BY BOARD_NO
+            ) cc ON cc.BOARD_NO = B.BOARD_NO
+            LEFT JOIN (
+                SELECT BOARD_NO, COUNT(*) AS CNT FROM BOARD_LIKE GROUP BY BOARD_NO
+            ) lc ON lc.BOARD_NO = B.BOARD_NO
             WHERE B.MEMBER_NO = #{memberNo}
               AND B.STATUS = 'A'
         )
@@ -259,11 +265,13 @@
                 TO_CHAR(CB.TRAVEL_DATE, 'YYYY-MM-DD') AS "travelDate",
                 TO_CHAR(CB.CREATED_AT, 'YYYY-MM-DD') AS "createdAt",
                 CB.IMAGE_URL AS "imageUrl",
-                (SELECT COUNT(*) FROM COMPANION_JOIN J
-                 WHERE J.COMPANION_NO = CB.COMPANION_NO
-                   AND J.STATUS IN ('W', 'A')) AS "currentMembers",
+                NVL(jc.CNT, 0) AS "currentMembers",
                 ROW_NUMBER() OVER (ORDER BY CB.CREATED_AT DESC) AS RN
             FROM COMPANION_BOARD CB
+            LEFT JOIN (
+                SELECT COMPANION_NO, COUNT(*) AS CNT
+                FROM COMPANION_JOIN WHERE STATUS IN ('W', 'A') GROUP BY COMPANION_NO
+            ) jc ON jc.COMPANION_NO = CB.COMPANION_NO
             WHERE CB.MEMBER_NO = #{memberNo}
               AND CB.STATUS != 'D'
         )

--- a/finalProject/fronted/src/pages/accommodation/Accommodations.jsx
+++ b/finalProject/fronted/src/pages/accommodation/Accommodations.jsx
@@ -69,7 +69,7 @@ export default function Accommodations() {
   // 클라이언트 필터 없을 때 → 서버 페이지네이션 (size=9)
   // 클라이언트 필터 있을 때 → 전체 로드 후 프론트 필터링 (size=200)
   const serverPage = hasClientFilters ? 1 : currentPage;
-  const serverSize = hasClientFilters ? 200 : pageSize;
+  const serverSize = hasClientFilters ? 50 : pageSize;
 
   const { data, isLoading, isError, error, refetch } = useAccommodations(serverPage, serverSize, regionParam);
 

--- a/finalProject/fronted/vite.config.ts
+++ b/finalProject/fronted/vite.config.ts
@@ -14,6 +14,8 @@ export default defineConfig(({ command }) => ({
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   esbuild: { drop: command === 'build' ? ['console', 'debugger'] : [] } as any,
   build: {
+    target: 'es2020',
+    cssMinify: 'esbuild',
     rollupOptions: {
       output: {
         manualChunks(id: string) {
@@ -24,6 +26,8 @@ export default defineConfig(({ command }) => ({
             if (id.includes('@tanstack/react-query')) return 'vendor-query';
             if (id.includes('react-router-dom') || id.includes('react-router')) return 'vendor-router';
             if (id.includes('react-dom') || id.includes('/react/')) return 'vendor-react';
+            if (id.includes('sockjs-client')) return 'vendor-sockjs';
+            if (id.includes('date-fns')) return 'vendor-datefns';
           }
         },
       },


### PR DESCRIPTION
## Summary

Dev_CCL → development → main 으로의 성능 최적화 통합 머지

### Backend
- **상관 서브쿼리 → LEFT JOIN 변환**: activity/freeboard/companion/member 매퍼의 상관 서브쿼리를 LEFT JOIN + GROUP BY 패턴으로 변환하여 게시글 목록/상세 조회 시 N+1 패턴 제거
- **CacheConfig 강화**: maximumSize 500, expireAfterAccess 10분, memberStats 캐시 추가
- **@Transactional(readOnly=true) 누락 보완**: MemberServiceImpl(5개 메서드), SpotServiceImpl(2개 메서드) — 읽기 전용 트랜잭션으로 커넥션 풀 효율 개선
- **회원 프로필 통계 캐싱**: getMemberWithStats에 @Cacheable 적용

### Frontend
- **숙소 필터 fetch 최적화**: 200건→50건 축소 (네트워크 부하 75% 감소)
- **Vite 빌드 최적화**: 추가 청크 분리(sockjs-client, date-fns), cssMinify, target es2020

## Test plan
- [ ] 자유게시판/행사게시판 목록 및 상세 조회
- [ ] 동행 상세 조회 참여자 수 표시
- [ ] 회원 프로필 통계
- [ ] 숙소 검색/필터링
- [ ] 프론트엔드 빌드