### PR TITLE
[Perf] 숙소 TourAPI 병렬 호출 및 관리자 페이징/검색 인덱스 추가

### DIFF
--- a/finalProject/backend/lombok.config
+++ b/finalProject/backend/lombok.config
@@ -1,0 +1,1 @@
+lombok.copyableAnnotations += org.springframework.beans.factory.annotation.Qualifier

--- a/finalProject/backend/src/main/java/edu/kh/project/accommodation/service/AccommodationServiceImpl.java
+++ b/finalProject/backend/src/main/java/edu/kh/project/accommodation/service/AccommodationServiceImpl.java
@@ -1,11 +1,15 @@
 package edu.kh.project.accommodation.service;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,6 +35,9 @@ public class AccommodationServiceImpl implements AccommodationService {
 
     private final AccommodationMapper accommodationMapper;
     private final RuralApiService ruralApiService;
+
+    @Qualifier("tourApiExecutor")
+    private final Executor tourApiExecutor;
 
     @Override
     public int syncAccommodationsFromApi() {
@@ -93,21 +100,38 @@ public class AccommodationServiceImpl implements AccommodationService {
             int reclassified = accommodationMapper.reclassifyAccommodationTypes();
             log.info("숙소 유형 재분류 완료: {}건", reclassified);
 
-            // 5) 상세정보 수집 (detailIntro2 + detailInfo2 + detailCommon2)
-            log.info("===== 상세정보 수집 시작 =====");
+            // 5) 상세정보 수집 (detailIntro2 + detailInfo2 + detailCommon2) - 병렬 호출
+            log.info("===== 상세정보 수집 시작 (병렬) =====");
             List<AccommodationDTO> allAccom = accommodationMapper.selectAllActiveAccommodations();
-            int detailCount = 0;
 
+            List<CompletableFuture<AccommodationDTO>> futures = new ArrayList<>(allAccom.size());
             for (AccommodationDTO acc : allAccom) {
+                CompletableFuture<AccommodationDTO> f = CompletableFuture.supplyAsync(() -> {
+                    try {
+                        fillDetailInfo(acc);
+                        return acc;
+                    } catch (Exception e) {
+                        log.warn("상세정보 수집 실패: {} - {}", acc.getName(), e.getMessage());
+                        return null;
+                    }
+                }, tourApiExecutor);
+                futures.add(f);
+            }
+            CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+
+            // DB 업데이트는 순차 수행 (JDBC 커넥션풀 보호)
+            int detailCount = 0;
+            for (CompletableFuture<AccommodationDTO> f : futures) {
+                AccommodationDTO acc = f.join();
+                if (acc == null) continue;
                 try {
-                    fillDetailInfo(acc);
                     accommodationMapper.updateAccommodationDetail(acc);
                     detailCount++;
-                    if (detailCount % 20 == 0) {
-                        log.info("상세정보 수집 진행: {}/{}", detailCount, allAccom.size());
+                    if (detailCount % 50 == 0) {
+                        log.info("상세정보 DB 반영: {}/{}", detailCount, allAccom.size());
                     }
                 } catch (Exception e) {
-                    log.warn("상세정보 수집 실패: {} - {}", acc.getName(), e.getMessage());
+                    log.warn("상세정보 업데이트 실패: {} - {}", acc.getName(), e.getMessage());
                 }
             }
             log.info("상세정보 수집 완료: {}/{}건", detailCount, allAccom.size());

--- a/finalProject/backend/src/main/java/edu/kh/project/common/config/AsyncConfig.java
+++ b/finalProject/backend/src/main/java/edu/kh/project/common/config/AsyncConfig.java
@@ -1,0 +1,24 @@
+package edu.kh.project.common.config;
+
+import java.util.concurrent.Executor;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean(name = "tourApiExecutor")
+    public Executor tourApiExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(10);
+        executor.setMaxPoolSize(20);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("tour-api-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/finalProject/backend/src/main/resources/sql/performance-indexes.sql
+++ b/finalProject/backend/src/main/resources/sql/performance-indexes.sql
@@ -26,3 +26,21 @@ CREATE INDEX IDX_COMMENT_BOARD ON COMMENT_TBL(BOARD_NO);
 
 -- 알림 조회 (수신자별 미읽음 알림 조회)
 CREATE INDEX IDX_NOTIFICATION_RECIP ON NOTIFICATION(RECIPIENT_NO, IS_READ);
+
+-- ============================================================
+-- 관리자 목록 페이징 정렬 최적화
+-- ROW_NUMBER() OVER (ORDER BY CREATED_AT DESC) 쿼리의 정렬 비용 제거
+-- ============================================================
+
+CREATE INDEX IDX_COMPANION_CREATED ON COMPANION_BOARD(CREATED_AT DESC);
+CREATE INDEX IDX_COMP_REVIEW_CREATED ON COMPANION_REVIEW(CREATED_AT DESC);
+CREATE INDEX IDX_ACCOM_CREATED ON ACCOMMODATION(CREATED_AT DESC);
+
+-- ============================================================
+-- 검색/필터 컬럼 인덱스
+-- 관리자 목록 WHERE STATUS 조건, 닉네임 검색 등
+-- ============================================================
+
+CREATE INDEX IDX_MEMBER_NICKNAME ON MEMBER(NICKNAME);
+CREATE INDEX IDX_ACCOM_STATUS ON ACCOMMODATION(STATUS);
+CREATE INDEX IDX_COMPANION_STATUS ON COMPANION_BOARD(STATUS);


### PR DESCRIPTION
## Summary

잔여 성능 병목 3종을 정리하는 최적화 PR입니다.

### 1. 숙소 TourAPI 동기 호출 병렬화 (가장 큰 체감 효과)
- `AccommodationServiceImpl.syncAccommodationsFromApi()` 의 상세정보 수집 단계(detailIntro2/detailInfo2/detailCommon2)가 숙소 N개당 3 × N 회의 동기 HTTP 호출을 순차 실행하던 문제 해결
- 새로운 `AsyncConfig` 에 `tourApiExecutor` ThreadPool Bean 도입 (core=10, max=20, queue=100)
- 각 숙소의 상세정보 호출을 `CompletableFuture.supplyAsync(..., tourApiExecutor)` 로 병렬 실행 후 `allOf().join()` 로 수렴
- **DB update 는 순차 수행** — JDBC 커넥션풀 과다 점유 방지
- `@EnableAsync` 활성화 및 lombok `@Qualifier` 전파용 `lombok.config` 추가

### 2. 관리자 페이징 쿼리 정렬 인덱스 추가
`ROW_NUMBER() OVER (ORDER BY C.CREATED_AT DESC)` 기반 페이징 쿼리가 정렬 컬럼 인덱스 부재로 풀스캔+정렬 발생.
아래 DESC 인덱스 3종 추가:

```sql
CREATE INDEX IDX_COMPANION_CREATED ON COMPANION_BOARD(CREATED_AT DESC);
CREATE INDEX IDX_COMP_REVIEW_CREATED ON COMPANION_REVIEW(CREATED_AT DESC);
CREATE INDEX IDX_ACCOM_CREATED ON ACCOMMODATION(CREATED_AT DESC);
```

### 3. 검색/필터 컬럼 인덱스 추가
관리자 목록 `WHERE STATUS ...` / 닉네임 검색 대비:

```sql
CREATE INDEX IDX_MEMBER_NICKNAME ON MEMBER(NICKNAME);
CREATE INDEX IDX_ACCOM_STATUS ON ACCOMMODATION(STATUS);
CREATE INDEX IDX_COMPANION_STATUS ON COMPANION_BOARD(STATUS);
```

## 변경 파일
- `backend/src/main/java/edu/kh/project/common/config/AsyncConfig.java` (신규)
- `backend/src/main/java/edu/kh/project/accommodation/service/AccommodationServiceImpl.java`
- `backend/src/main/resources/sql/performance-indexes.sql`
- `backend/lombok.config` (신규) — `@Qualifier` copyableAnnotations 설정

## 배포 주의사항
- `performance-indexes.sql` 신규 추가 블록을 **운영 Oracle 에 수동 실행** 필요
- 롤백 시 `DROP INDEX IDX_COMPANION_CREATED;` 등

## Test plan
- [x] `gradlew clean compileJava` 성공
- [ ] 로컬 구동 후 `AsyncConfig` / `tourApiExecutor` Bean 등록 로그 확인
- [ ] 숙소 동기화 트리거 시 `tour-api-*` 스레드에서 병렬 호출 + 전체 소요시간 단축 확인
- [ ] 관리자 목록 `/admin/companions`, `/admin/reviews`, `/admin/accommodations` 페이지네이션 정상
- [ ] 운영 DB 에 인덱스 DDL 수동 적용