### PR TITLE
[Perf] 프론트 초기 로딩 최적화 (폰트/SDK/DevTools/빌드)

### DIFF
--- a/finalProject/fronted/index.html
+++ b/finalProject/fronted/index.html
@@ -5,25 +5,32 @@
     <link rel="icon" type="image/svg+xml" href="/HONDI.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>혼디</title>
-    <!-- 한글 폰트 -->
+    <!-- 외부 리소스 사전 연결 (DNS/TLS 핸드셰이크 선행) -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;700;900&family=Gothic+A1:wght@700;900&display=swap" rel="stylesheet">
-    <!-- Pretendard & Gmarket Sans -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/fonts-archive/GmarketSans/GmarketSans.css">
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+    <link rel="preconnect" href="https://dapi.kakao.com">
+    <link rel="preconnect" href="https://t1.kakaocdn.net" crossorigin>
+    <!-- 한글 폰트 (display=swap으로 FOUT 방지, 렌더 블로킹 회피) -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;700;900&family=Gothic+A1:wght@700;900&display=swap" media="print" onload="this.media='all'">
+    <!-- Pretendard & Gmarket Sans (비동기 로드) -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css" media="print" onload="this.media='all'">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/fonts-archive/GmarketSans/GmarketSans.css" media="print" onload="this.media='all'">
   </head>
   <body>
     <div id="root"></div>
     <script>var global = globalThis;</script>
-    <!-- Kakao Maps SDK -->
-    <script type="text/javascript" src="//dapi.kakao.com/v2/maps/sdk.js?appkey=d9dd19e9fb95ab8245e1a46f41ba4b5a&autoload=false&libraries=services"></script>
+    <!-- Kakao Maps SDK (defer: HTML 파싱 비블로킹) -->
+    <script defer src="https://dapi.kakao.com/v2/maps/sdk.js?appkey=d9dd19e9fb95ab8245e1a46f41ba4b5a&autoload=false&libraries=services"></script>
     <!-- Kakao JS SDK (공유 기능) -->
-    <script src="https://t1.kakaocdn.net/kakao_js_sdk/2.7.2/kakao.min.js" integrity="sha384-TiCUE00h649CAMonG018J2ujOgDKW/kVWlChEuu4jK2vxfAAD0eZxzCKakxg55G4" crossorigin="anonymous"></script>
+    <script defer src="https://t1.kakaocdn.net/kakao_js_sdk/2.7.2/kakao.min.js" integrity="sha384-TiCUE00h649CAMonG018J2ujOgDKW/kVWlChEuu4jK2vxfAAD0eZxzCKakxg55G4" crossorigin="anonymous"></script>
     <script>
-      if (window.Kakao && !window.Kakao.isInitialized()) {
-        window.Kakao.init('d9dd19e9fb95ab8245e1a46f41ba4b5a');
-      }
+      // defer 스크립트는 DOMContentLoaded 직전에 실행되므로 해당 이벤트에서 초기화
+      window.addEventListener('DOMContentLoaded', function () {
+        if (window.Kakao && !window.Kakao.isInitialized()) {
+          window.Kakao.init('d9dd19e9fb95ab8245e1a46f41ba4b5a');
+        }
+      });
     </script>
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/finalProject/fronted/src/App.jsx
+++ b/finalProject/fronted/src/App.jsx
@@ -5,8 +5,11 @@ import { lazy, Suspense } from 'react';
 import { AuthProvider } from './components/AuthContext';
 import { BrowserRouter, Routes, Route, useLocation } from 'react-router-dom';
 import { QueryClientProvider } from '@tanstack/react-query';
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { queryClientInstance } from './lib/query-client';
+// DevTools는 개발 환경에서만 동적 로드 → 프로덕션 번들에서 완전 제거
+const ReactQueryDevtools = import.meta.env.DEV
+  ? lazy(() => import('@tanstack/react-query-devtools').then(m => ({ default: m.ReactQueryDevtools })))
+  : null;
 import { AnimatePresence } from 'framer-motion';
 import PageTransition from './components/common/PageTransition';
 const ChatBubble    = lazy(() => import('./components/chatting/ChatBubble'));
@@ -125,7 +128,11 @@ function App() {
           </div>
         </BrowserRouter>
       </AuthProvider>
-      {import.meta.env.DEV && <ReactQueryDevtools initialIsOpen={false} />}
+      {import.meta.env.DEV && ReactQueryDevtools && (
+        <Suspense fallback={null}>
+          <ReactQueryDevtools initialIsOpen={false} />
+        </Suspense>
+      )}
     </QueryClientProvider>
   );
 }

--- a/finalProject/fronted/vite.config.ts
+++ b/finalProject/fronted/vite.config.ts
@@ -15,19 +15,22 @@ export default defineConfig(({ command }) => ({
   esbuild: { drop: command === 'build' ? ['console', 'debugger'] : [] } as any,
   build: {
     target: 'es2020',
-    cssMinify: 'esbuild',
+    reportCompressedSize: false, // gzip 크기 리포트 생략 → 빌드 시간 단축
+    chunkSizeWarningLimit: 1000,
     rollupOptions: {
       output: {
         manualChunks(id: string) {
           if (id.includes('node_modules')) {
             if (id.includes('framer-motion')) return 'vendor-motion';
             if (id.includes('@radix-ui')) return 'vendor-radix';
-            if (id.includes('lucide-react')) return 'vendor-icons';
+            if (id.includes('lucide-react') || id.includes('react-icons')) return 'vendor-icons';
             if (id.includes('@tanstack/react-query')) return 'vendor-query';
             if (id.includes('react-router-dom') || id.includes('react-router')) return 'vendor-router';
             if (id.includes('react-dom') || id.includes('/react/')) return 'vendor-react';
             if (id.includes('sockjs-client')) return 'vendor-sockjs';
             if (id.includes('date-fns')) return 'vendor-datefns';
+            if (id.includes('embla-carousel')) return 'vendor-embla';
+            if (id.includes('axios')) return 'vendor-axios';
           }
         },
       },


### PR DESCRIPTION
## Summary
프론트엔드 초기 로딩 성능을 개선하기 위해 렌더 블로킹 리소스를 제거하고, 프로덕션 번들에서 개발 전용 코드를 분리했습니다.

## 변경 사항

### 1. `fronted/index.html` — 외부 리소스 비동기화
- **preconnect 확장**: `cdn.jsdelivr.net`, `dapi.kakao.com`, `t1.kakaocdn.net` 추가 → DNS/TLS 핸드셰이크 선행으로 실제 요청 레이턴시 단축
- **폰트 CSS 렌더 블로킹 제거**: Noto Sans KR / Pretendard / Gmarket Sans 를 `media=\"print\" onload=\"this.media='all'\"` 패턴으로 비동기 로드 (기존엔 `<link rel=\"stylesheet\">` 가 HTML 파싱을 블로킹)
- **Kakao SDK `defer` 적용**: Kakao Maps SDK, Kakao JS SDK 에 `defer` 부여 → 파싱 블로킹 해소
- **Kakao.init 타이밍 보정**: defer 로 변경되면서 인라인 init 스크립트가 SDK 로드 전 실행되던 문제를 `DOMContentLoaded` 이벤트에서 초기화하도록 수정

### 2. `fronted/src/App.jsx` — ReactQueryDevtools 동적 로드
- 기존: `import { ReactQueryDevtools } from '@tanstack/react-query-devtools'` 정적 import → `import.meta.env.DEV` 체크가 있어도 번들에 포함될 수 있음
- 변경: `DEV` 환경에서만 `lazy(() => import(...))` 로 동적 로드 → **프로덕션 번들에서 devtools 코드 완전 제거**

### 3. `fronted/vite.config.ts` — 빌드 설정 개선
- `cssMinify: 'esbuild'` 제거: rolldown-vite 환경에서 esbuild 미설치로 빌드 실패하던 이슈 해결, 기본(oxc) 미니파이어 사용
- `reportCompressedSize: false`: gzip 사이즈 계산 생략 → **빌드 시간 단축**
- `chunkSizeWarningLimit: 1000`: 불필요한 경고 억제
- `manualChunks` 확장: `react-icons`, `embla-carousel`, `axios` 를 별도 vendor 청크로 분리 → 장기 캐싱 효율 개선

## 기대 효과
- **LCP/FCP 개선**: 폰트 CSS·Kakao SDK 가 더 이상 초기 렌더를 블로킹하지 않음
- **프로덕션 JS 번들 경량화**: DevTools 제거
- **브라우저 캐시 재사용률 증가**: vendor 청크 추가 분리로, 앱 코드만 변경 시 사용자가 vendor 재다운로드 불필요
- **CI 빌드 속도 향상**: compressed size 리포트 생략

## Test plan
- [x] `npm run build` 정상 완료 확인
- [ ] 배포 후 브라우저에서 Kakao 지도/공유 기능 정상 동작 확인
- [ ] Lighthouse 로 LCP/FCP 개선 수치 측정
- [ ] 프로덕션 번들에 `react-query-devtools` 미포함 확인