### PR TITLE
[Perf] 알림 배치 INSERT·카운트 캐시, 동행 쿼리 통합, 댓글 트리 단일 패스, AuthContext 중복 갱신 제거

### DIFF
--- a/finalProject/backend/src/main/java/edu/kh/project/common/config/CacheConfig.java
+++ b/finalProject/backend/src/main/java/edu/kh/project/common/config/CacheConfig.java
@@ -17,7 +17,7 @@ public class CacheConfig {
     @Bean
     public CacheManager cacheManager() {
         CaffeineCacheManager manager = new CaffeineCacheManager(
-                "dashboardStats", "activeSpots", "memberStats"
+                "dashboardStats", "activeSpots", "memberStats", "notificationCount"
         );
         manager.setCaffeine(Caffeine.newBuilder()
                 .expireAfterAccess(10, TimeUnit.MINUTES)
@@ -25,7 +25,3 @@ public class CacheConfig {
         return manager;
     }
 }
-
-
-
-

--- a/finalProject/backend/src/main/java/edu/kh/project/companion/dto/CompanionJoinDTO.java
+++ b/finalProject/backend/src/main/java/edu/kh/project/companion/dto/CompanionJoinDTO.java
@@ -27,4 +27,8 @@ public class CompanionJoinDTO {
     // JOIN 파생 필드 (신청자 정보)
     private String memberNickname; // 신청자 닉네임
     private String memberProfile;  // 신청자 프로필 이미지
+
+    // JOIN 파생 필드 (동행 게시글 정보 - 알림 생성용)
+    private String companionTitle;   // 동행 게시글 제목
+    private Integer companionAuthorNo; // 동행 게시글 작성자 번호
 }

--- a/finalProject/backend/src/main/java/edu/kh/project/companion/service/CompanionServiceImpl.java
+++ b/finalProject/backend/src/main/java/edu/kh/project/companion/service/CompanionServiceImpl.java
@@ -242,38 +242,39 @@ public class CompanionServiceImpl implements CompanionService {
         // 승인/거절 시 신청자에게 알림 전송
         if (result > 0 && ("A".equals(status) || "R".equals(status))) {
             try {
+                // LEFT JOIN으로 동행 제목/작성자까지 한 번에 조회 (이전 2쿼리 → 1쿼리)
                 CompanionJoinDTO join = companionMapper.selectJoinByJoinNo(joinNo);
-                if (join != null) {
-                    CompanionDTO companion = companionMapper.selectCompanionDetail(join.getCompanionNo());
-                    if (companion != null) {
-                        String type = "A".equals(status) ? "COMPANION_ACCEPTED" : "COMPANION_REJECTED";
-                        String title = "A".equals(status) ? "동행 신청 승인" : "동행 신청 거절";
-                        String content = "A".equals(status)
-                                ? "'" + companion.getTitle() + "' 동행 신청이 승인되었습니다."
-                                : "'" + companion.getTitle() + "' 동행 신청이 거절되었습니다.";
+                if (join != null && join.getCompanionTitle() != null) {
+                    String companionTitle = join.getCompanionTitle();
+                    Integer companionAuthorNo = join.getCompanionAuthorNo();
 
-                        NotificationDTO notification = NotificationDTO.builder()
-                                .recipientNo(join.getMemberNo())
-                                .senderNo(memberNo)
-                                .notificationType(type)
-                                .targetType("COMPANION")
-                                .targetNo(join.getCompanionNo())
-                                .title(title)
-                                .content(content)
-                                .build();
-                        notificationService.createNotification(notification);
+                    String type = "A".equals(status) ? "COMPANION_ACCEPTED" : "COMPANION_REJECTED";
+                    String title = "A".equals(status) ? "동행 신청 승인" : "동행 신청 거절";
+                    String content = "A".equals(status)
+                            ? "'" + companionTitle + "' 동행 신청이 승인되었습니다."
+                            : "'" + companionTitle + "' 동행 신청이 거절되었습니다.";
 
-                        // 승인 시 그룹 채팅방 자동 생성 (실패해도 수락 트랜잭션 롤백 안 함)
-                        if ("A".equals(status)) {
-                            try {
-                                groupChatService.createGroupRoom(
-                                    join.getCompanionNo(),
-                                    companion.getTitle(),
-                                    List.of(companion.getMemberNo(), join.getMemberNo())
-                                );
-                            } catch (Exception e) {
-                                log.warn("그룹 채팅방 생성 실패 - joinNo: {}", joinNo, e);
-                            }
+                    NotificationDTO notification = NotificationDTO.builder()
+                            .recipientNo(join.getMemberNo())
+                            .senderNo(memberNo)
+                            .notificationType(type)
+                            .targetType("COMPANION")
+                            .targetNo(join.getCompanionNo())
+                            .title(title)
+                            .content(content)
+                            .build();
+                    notificationService.createNotification(notification);
+
+                    // 승인 시 그룹 채팅방 자동 생성 (실패해도 수락 트랜잭션 롤백 안 함)
+                    if ("A".equals(status) && companionAuthorNo != null) {
+                        try {
+                            groupChatService.createGroupRoom(
+                                join.getCompanionNo(),
+                                companionTitle,
+                                List.of(companionAuthorNo, join.getMemberNo())
+                            );
+                        } catch (Exception e) {
+                            log.warn("그룹 채팅방 생성 실패 - joinNo: {}", joinNo, e);
                         }
                     }
                 }

--- a/finalProject/backend/src/main/java/edu/kh/project/freeboard/service/FreeBoardServiceImpl.java
+++ b/finalProject/backend/src/main/java/edu/kh/project/freeboard/service/FreeBoardServiceImpl.java
@@ -3,7 +3,6 @@ package edu.kh.project.freeboard.service;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -137,28 +136,27 @@ public class FreeBoardServiceImpl implements FreeBoardService {
     @Override
     @Transactional(readOnly = true)
     public List<CommentDTO> getCommentList(int boardNo) {
+        // SQL이 NVL(PARENT_COMMENT_NO, COMMENT_NO)로 정렬해 부모 다음에 해당 자식들이 연속되므로
+        // 단일 패스 O(n)으로 트리 구성 가능 (기존 2-pass + 2개 컬렉션 → 1-pass + 1개 Map)
         List<CommentDTO> allComments = freeBoardMapper.selectAllComments(boardNo);
 
-        Map<Integer, CommentDTO> parentMap = new LinkedHashMap<>();
-        List<CommentDTO> children = new ArrayList<>();
+        List<CommentDTO> parents = new ArrayList<>();
+        Map<Integer, CommentDTO> parentMap = new HashMap<>();
 
         for (CommentDTO c : allComments) {
             if (c.getParentCommentNo() == null) {
                 c.setReplies(new ArrayList<>());
+                parents.add(c);
                 parentMap.put(c.getCommentNo(), c);
             } else {
-                children.add(c);
+                CommentDTO parent = parentMap.get(c.getParentCommentNo());
+                if (parent != null) {
+                    parent.getReplies().add(c);
+                }
             }
         }
 
-        for (CommentDTO child : children) {
-            CommentDTO parent = parentMap.get(child.getParentCommentNo());
-            if (parent != null) {
-                parent.getReplies().add(child);
-            }
-        }
-
-        return new ArrayList<>(parentMap.values());
+        return parents;
     }
 
     @Override

--- a/finalProject/backend/src/main/java/edu/kh/project/notification/mapper/NotificationMapper.java
+++ b/finalProject/backend/src/main/java/edu/kh/project/notification/mapper/NotificationMapper.java
@@ -20,6 +20,9 @@ public interface NotificationMapper {
     /** 알림 등록 */
     int insert(NotificationDTO notification);
 
+    /** 알림 일괄 등록 (브로드캐스트) */
+    int insertBatch(@Param("list") List<NotificationDTO> list);
+
     /** 알림 목록 조회 (페이징) */
     List<NotificationDTO> selectList(
         @Param("recipientNo") int recipientNo,

--- a/finalProject/backend/src/main/java/edu/kh/project/notification/service/NotificationServiceImpl.java
+++ b/finalProject/backend/src/main/java/edu/kh/project/notification/service/NotificationServiceImpl.java
@@ -6,9 +6,12 @@ import edu.kh.project.notification.mapper.NotificationMapper;
 import edu.kh.project.websocket.handler.NotificationWebSocketHandler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -30,6 +33,7 @@ public class NotificationServiceImpl implements NotificationService {
     private final AdminMapper adminMapper;
 
     @Override
+    @CacheEvict(value = "notificationCount", key = "#notification.recipientNo")
     public void createNotification(NotificationDTO notification) {
         // DB 저장
         notificationMapper.insert(notification);
@@ -46,11 +50,15 @@ public class NotificationServiceImpl implements NotificationService {
     }
 
     @Override
+    @CacheEvict(value = "notificationCount", allEntries = true)
     public void notifyAllAdmins(NotificationDTO template) {
         List<Integer> adminNos = adminMapper.selectAdminMemberNos();
+        if (adminNos == null || adminNos.isEmpty()) return;
 
+        // 1. 관리자별 NotificationDTO 구성
+        List<NotificationDTO> notifications = new ArrayList<>(adminNos.size());
         for (int adminNo : adminNos) {
-            NotificationDTO notification = NotificationDTO.builder()
+            notifications.add(NotificationDTO.builder()
                     .recipientNo(adminNo)
                     .senderNo(template.getSenderNo())
                     .notificationType(template.getNotificationType())
@@ -58,8 +66,19 @@ public class NotificationServiceImpl implements NotificationService {
                     .targetNo(template.getTargetNo())
                     .title(template.getTitle())
                     .content(template.getContent())
-                    .build();
-            createNotification(notification);
+                    .build());
+        }
+
+        // 2. 단일 INSERT ALL로 DB 일괄 저장
+        notificationMapper.insertBatch(notifications);
+
+        // 3. WebSocket 브로드캐스트 (개별 실패가 전체를 막지 않도록 try/catch)
+        for (NotificationDTO n : notifications) {
+            try {
+                notificationWebSocketHandler.sendToUser(n.getRecipientNo(), n);
+            } catch (Exception e) {
+                log.warn("알림 WebSocket push 실패 - recipientNo: {}", n.getRecipientNo(), e);
+            }
         }
     }
 
@@ -72,6 +91,7 @@ public class NotificationServiceImpl implements NotificationService {
 
     @Override
     @Transactional(readOnly = true)
+    @Cacheable(value = "notificationCount", key = "#recipientNo")
     public int getNotificationCount(int recipientNo) {
         return notificationMapper.selectCount(recipientNo);
     }
@@ -93,11 +113,13 @@ public class NotificationServiceImpl implements NotificationService {
     }
 
     @Override
+    @CacheEvict(value = "notificationCount", key = "#recipientNo")
     public int deleteNotification(int notificationNo, int recipientNo) {
         return notificationMapper.deleteNotification(notificationNo, recipientNo);
     }
 
     @Override
+    @CacheEvict(value = "notificationCount", key = "#recipientNo")
     public int deleteAllNotifications(int recipientNo) {
         return notificationMapper.deleteAllNotifications(recipientNo);
     }

--- a/finalProject/backend/src/main/resources/mappers/companion-mapper.xml
+++ b/finalProject/backend/src/main/resources/mappers/companion-mapper.xml
@@ -36,6 +36,8 @@
         <result property="createdAt" column="CREATED_AT" />
         <result property="memberNickname" column="MEMBER_NICKNAME" />
         <result property="memberProfile" column="MEMBER_PROFILE" />
+        <result property="companionTitle" column="COMPANION_TITLE" />
+        <result property="companionAuthorNo" column="COMPANION_AUTHOR_NO" />
     </resultMap>
 
     <!-- 목록 조회 (페이징 + 태그 필터) -->
@@ -217,7 +219,7 @@
           AND STATUS IN ('W', 'A')
     </select>
 
-    <!-- 참여 신청 단건 조회 (알림용) -->
+    <!-- 참여 신청 단건 조회 (알림용 - 동행 게시글 제목/작성자까지 LEFT JOIN으로 1쿼리 처리) -->
     <select id="selectJoinByJoinNo" resultMap="joinResultMap">
         SELECT
             J.JOIN_NO,
@@ -226,9 +228,12 @@
             J.STATUS,
             TO_CHAR(J.CREATED_AT, 'YYYY-MM-DD HH24:MI') AS CREATED_AT,
             M.NICKNAME AS MEMBER_NICKNAME,
-            M.PROFILE_IMAGE AS MEMBER_PROFILE
+            M.PROFILE_IMAGE AS MEMBER_PROFILE,
+            C.TITLE AS COMPANION_TITLE,
+            C.MEMBER_NO AS COMPANION_AUTHOR_NO
         FROM COMPANION_JOIN J
         JOIN MEMBER M ON J.MEMBER_NO = M.MEMBER_NO
+        LEFT JOIN COMPANION_BOARD C ON J.COMPANION_NO = C.COMPANION_NO
         WHERE J.JOIN_NO = #{joinNo}
     </select>
 

--- a/finalProject/backend/src/main/resources/mappers/freeboard-mapper.xml
+++ b/finalProject/backend/src/main/resources/mappers/freeboard-mapper.xml
@@ -232,23 +232,27 @@
         ORDER BY C.COMMENT_NO ASC
     </select>
 
-    <!-- 게시글의 모든 댓글 한번에 조회 (N+1 제거) -->
+    <!-- 게시글의 모든 댓글 한번에 조회 (N+1 제거, 과도한 메모리 사용 방지용 안전 한도 1000) -->
     <select id="selectAllComments" resultMap="commentResultMap">
-        SELECT
-            C.COMMENT_NO,
-            C.BOARD_NO,
-            C.MEMBER_NO,
-            C.PARENT_COMMENT_NO,
-            C.CONTENT,
-            C.STATUS,
-            TO_CHAR(C.CREATED_AT, 'YYYY-MM-DD HH24:MI') AS CREATED_AT,
-            M.NICKNAME AS MEMBER_NICKNAME,
-            M.PROFILE_IMAGE AS MEMBER_PROFILE
-        FROM COMMENT_TBL C
-        JOIN MEMBER M ON C.MEMBER_NO = M.MEMBER_NO
-        WHERE C.BOARD_NO = #{boardNo}
-          AND C.STATUS = 'A'
-        ORDER BY NVL(C.PARENT_COMMENT_NO, C.COMMENT_NO), C.COMMENT_NO ASC
+        SELECT *
+        FROM (
+            SELECT
+                C.COMMENT_NO,
+                C.BOARD_NO,
+                C.MEMBER_NO,
+                C.PARENT_COMMENT_NO,
+                C.CONTENT,
+                C.STATUS,
+                TO_CHAR(C.CREATED_AT, 'YYYY-MM-DD HH24:MI') AS CREATED_AT,
+                M.NICKNAME AS MEMBER_NICKNAME,
+                M.PROFILE_IMAGE AS MEMBER_PROFILE
+            FROM COMMENT_TBL C
+            JOIN MEMBER M ON C.MEMBER_NO = M.MEMBER_NO
+            WHERE C.BOARD_NO = #{boardNo}
+              AND C.STATUS = 'A'
+            ORDER BY NVL(C.PARENT_COMMENT_NO, C.COMMENT_NO), C.COMMENT_NO ASC
+        )
+        WHERE ROWNUM &lt;= 1000
     </select>
 
     <!-- 댓글 작성 -->

--- a/finalProject/backend/src/main/resources/mappers/notification-mapper.xml
+++ b/finalProject/backend/src/main/resources/mappers/notification-mapper.xml
@@ -34,6 +34,24 @@
         )
     </insert>
 
+    <!-- 알림 일괄 삽입 (Oracle INSERT ALL) -->
+    <insert id="insertBatch">
+        INSERT ALL
+        <foreach collection="list" item="n">
+            INTO NOTIFICATION (
+                NOTIFICATION_NO, RECIPIENT_NO, SENDER_NO,
+                NOTIFICATION_TYPE, TARGET_TYPE, TARGET_NO,
+                TITLE, CONTENT
+            ) VALUES (
+                SEQ_NOTIFICATION_NO.NEXTVAL,
+                #{n.recipientNo}, #{n.senderNo},
+                #{n.notificationType}, #{n.targetType}, #{n.targetNo},
+                #{n.title}, #{n.content}
+            )
+        </foreach>
+        SELECT 1 FROM DUAL
+    </insert>
+
     <!-- 알림 목록 조회 (페이징 + sender JOIN) -->
     <select id="selectList" resultMap="notificationResultMap">
         SELECT * FROM (

--- a/finalProject/fronted/src/components/AuthContext.tsx
+++ b/finalProject/fronted/src/components/AuthContext.tsx
@@ -1,8 +1,7 @@
-import { createContext, useState, useEffect, useCallback, useRef, ReactNode } from "react";
-import axios from "axios";
+import { createContext, useState, useEffect, useCallback, useMemo, useRef, ReactNode } from "react";
 import { axiosApi } from "../api/core/axiosAPI";
 import { getToken, saveToken, clearAllAuth } from "../api/core/tokenStorage";
-import type { Member, LoginResponse, RefreshResponse } from "../types";
+import type { Member, LoginResponse } from "../types";
 
 /**
  * 인증 Context
@@ -38,7 +37,8 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   // ── 미활동 제한 시간 (30분) ──
   const INACTIVITY_LIMIT = 30 * 60 * 1000;
 
-  // 앱 시작 시 토큰 유효성 검증 및 만료된 accessToken 능동적 갱신
+  // 앱 시작 시 세션 유효성 체크 (미활동 타임아웃, 리프레시 토큰 부재 시 로그아웃)
+  // 만료된 accessToken 갱신은 axios 응답 인터셉터(401 → refresh)에 위임하여 중복 호출 제거.
   useEffect(() => {
     const token = getToken("accessToken");
     const refreshToken = getToken("refreshToken");
@@ -57,60 +57,10 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       return;
     }
 
-    // accessToken 만료 여부 확인
-    let isExpired = false;
-    if (token) {
-      try {
-        const payload = JSON.parse(atob(token.split('.')[1]));
-        isExpired = payload.exp * 1000 < Date.now();
-      } catch {
-        isExpired = true;
-      }
-    } else {
-      isExpired = true; // 토큰 자체가 없으면 만료 취급
-    }
-
-    if (isExpired) {
-      if (!refreshToken) {
-        // 리프레시 토큰도 없으면 → 완전 로그아웃
-        clearAllAuth();
-        setUser(null);
-        return;
-      }
-
-      // 리프레시 토큰으로 능동적 갱신 시도 (plain axios로 interceptor 순환 방지)
-      axios.post<{ success: boolean; data: RefreshResponse }>("/api/member/refresh", { refreshToken })
-        .then((response) => {
-          if (response.data.success) {
-            const { accessToken, refreshToken: newRefreshToken } = response.data.data;
-            saveToken("accessToken", accessToken);
-            saveToken("refreshToken", newRefreshToken);
-            // userData도 갱신
-            const data = response.data.data;
-            const parsed = JSON.parse(storedUser);
-            const updated: Member = {
-              ...parsed,
-              memberNo: data.memberNo ?? parsed.memberNo,
-              memberName: data.memberName ?? parsed.memberName,
-              memberNickname: data.memberNickname ?? parsed.memberNickname,
-              memberEmail: data.memberEmail ?? parsed.memberEmail,
-              memberProfileImg: data.memberProfileImg || parsed.memberProfileImg,
-              memberPhone: data.memberPhone || parsed.memberPhone || '',
-              memberIntro: data.memberIntro || parsed.memberIntro || '',
-            };
-            setUser(updated);
-            saveToken("userData", JSON.stringify(updated));
-          } else {
-            clearAllAuth();
-            setUser(null);
-            alert("인증이 만료되어 자동 로그아웃 되었습니다. 다시 로그인해 주세요.");
-          }
-        })
-        .catch(() => {
-          clearAllAuth();
-          setUser(null);
-          alert("인증이 만료되어 자동 로그아웃 되었습니다. 다시 로그인해 주세요.");
-        });
+    // accessToken도 refreshToken도 없으면 즉시 로그아웃 처리
+    if (!token && !refreshToken) {
+      clearAllAuth();
+      setUser(null);
     }
   }, []);
 
@@ -291,7 +241,8 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   };
 
   // 자식 컴포넌트에게 전달할 데이터를 하나로 묶기
-  const globalState: AuthContextType = {
+  // 불필요한 context 소비자 리렌더 방지를 위해 useMemo로 식별성 유지
+  const globalState: AuthContextType = useMemo(() => ({
     user,
     setUser,
     email,
@@ -301,7 +252,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     handleLogin,
     handleOAuthCallback,
     handleLogout
-  };
+  }), [user, email, password]);
 
   return (
     <AuthContext.Provider value={globalState}>


### PR DESCRIPTION
## 개요

성능 최적화 작업 묶음입니다. 알림 브로드캐스트 쿼리 수 대폭 감소, 동행 신청 알림 경로 쿼리 통합, 자유게시판 댓글 트리 구성 알고리즘 개선, 프론트 인증 초기화 중복 로직 제거, 그리고 Context 불필요한 리렌더 억제를 포함합니다.

## 변경 내용

### 1. 알림 브로드캐스트 배치 INSERT + 카운트 캐시
- **파일**: `CacheConfig.java`, `NotificationMapper.java`, `notification-mapper.xml`, `NotificationServiceImpl.java`
- **변경 전**: `notifyAllAdmins`가 관리자 N명에 대해 `createNotification()`을 N번 호출 → N개의 단일 INSERT + N번 트랜잭션/프록시/캐시 오버헤드
- **변경 후**:
  - Oracle `INSERT ALL`을 사용하는 `insertBatch` 매퍼 신설 → **1쿼리로 N건 일괄 삽입**
  - WebSocket 푸시는 개별 try/catch로 분리하여 부분 실패가 전체를 막지 않도록 유지
  - `getNotificationCount`에 `@Cacheable(\"notificationCount\")` 적용 → 배지 폴링 시 DB 부하 제거
  - `createNotification`, `deleteNotification`, `deleteAllNotifications`는 `@CacheEvict` 개별 키 무효화
  - `notifyAllAdmins`는 배치 INSERT 경로라 개별 키 무효화가 어려워 **`allEntries = true`**로 카운트 캐시를 일괄 무효화 (관리자 브로드캐스트는 빈도 낮고 캐시 자체가 배지용 카운트라 허용 범위)

### 2. 동행 신청 상태 변경 시 알림 경로 쿼리 통합
- **파일**: `CompanionJoinDTO.java`, `companion-mapper.xml`, `CompanionServiceImpl.java`
- **변경 전**: 승인/거절 후 알림 생성 시 `selectJoinByJoinNo` + `selectCompanionDetail` **2쿼리** 발생
- **변경 후**: `selectJoinByJoinNo`에 `COMPANION_BOARD` LEFT JOIN을 추가하여 게시글 제목/작성자까지 **1쿼리에 조회**
  - DTO에 `companionTitle`, `companionAuthorNo` 파생 필드 추가
  - 서비스 로직도 중첩 if 정리해서 가독성 개선

### 3. 자유게시판 댓글 트리 단일 패스 구성
- **파일**: `FreeBoardServiceImpl.java`, `freeboard-mapper.xml`
- **변경 전**: 부모/자식을 분리 저장한 뒤 자식 리스트를 다시 순회해 부모에 붙이는 **2-pass + 2개 컬렉션**
- **변경 후**: SQL이 이미 `NVL(PARENT_COMMENT_NO, COMMENT_NO)` 순으로 정렬해 **부모 직후 자식들이 연속 등장**하는 점을 활용해 **1-pass + 1개 Map**으로 축약
- 추가로 `selectAllComments`에 `ROWNUM <= 1000` 안전 한도를 둬 악의적/예외적 케이스에서 메모리 폭주 방지

### 4. 프론트 AuthContext 최적화
- **파일**: `fronted/src/components/AuthContext.tsx`
- **변경 전**: 앱 시작 시점에 토큰 만료 여부를 `atob`으로 판단하고 만료 시 `/api/member/refresh`를 **능동적으로 호출**
  - 문제: `axiosApi`는 이미 응답 인터셉터에서 401 발생 시 refresh → 재시도 로직을 가짐 → **중복 갱신 경로**가 존재해서 경쟁/중복 호출 위험
- **변경 후**:
  - 미활동 30분 체크, refreshToken 부재 시 강제 로그아웃만 남기고 능동적 갱신 로직 제거
  - 토큰 갱신은 **axios 응답 인터셉터 단일 경로로 통일**
  - 불필요한 `axios` 직접 import, `RefreshResponse` 타입 import 제거
- 추가: `AuthContext.Provider`의 `value`를 `useMemo`로 감싸 객체 참조를 안정화 → 하위 소비자 불필요 리렌더 억제

## 성능 기대 효과

| 경로 | 변경 전 | 변경 후 |
|---|---|---|
| 관리자 N명 알림 브로드캐스트 | INSERT × N, 프록시/트랜잭션 × N | INSERT 1회 |
| 알림 배지 카운트 폴링 | 매 호출 DB SELECT | Caffeine 캐시 히트(10분 access TTL) |
| 동행 승인/거절 알림 | SELECT × 2 | SELECT × 1 |
| 게시글 댓글 트리 구성 (n개) | O(n) 2-pass, 컬렉션 2개 | O(n) 1-pass, 컬렉션 1개 |
| 앱 시작 시 인증 처리 | 능동적 refresh + 인터셉터 refresh 경로 공존 | 인터셉터 단일 경로 |
| AuthContext 하위 렌더 | 매 상태 변경 시 참조 변동 | user/email/password 변경 시에만 갱신 |

## 검증

- [x] 백엔드 `./gradlew compileJava` BUILD SUCCESSFUL
- [x] 프론트 `tsc --noEmit` 기준 AuthContext 타입 오류 없음
- [ ] 관리자 신고/1:1 문의 발생 시 관리자 전원에게 실시간 알림이 도착하는지 확인
- [ ] 알림 삭제/생성 직후 배지 카운트가 즉시 반영되는지 확인 (캐시 evict 정상 동작)
- [ ] 동행 승인 시 그룹 채팅방 자동 생성 + 신청자 알림 도착 정상 동작
- [ ] 자유게시판 댓글/대댓글 트리 UI 정상 표시
- [ ] accessToken 만료 상태로 앱 진입 시 API 호출 → 401 → 자동 refresh → 재시도 성공

## 주의 사항

- `notifyAllAdmins`의 카운트 캐시 `allEntries = true` 무효화는 관리자 브로드캐스트 빈도가 낮다는 전제. 추후 일반 사용자 대상 브로드캐스트가 추가되면 개별 키 evict 방식으로 재검토 필요.
- `ROWNUM <= 1000`은 단순 안전 한도. 향후 댓글 페이지네이션 정식 도입 시 제거 또는 조정.