### PR TITLE
[Perf] 조회수 증가 비동기 처리 + 후기 매퍼 dead code 제거

### DIFF
--- a/finalProject/backend/src/main/java/edu/kh/project/accommodation/mapper/AccommodationReviewMapper.java
+++ b/finalProject/backend/src/main/java/edu/kh/project/accommodation/mapper/AccommodationReviewMapper.java
@@ -19,12 +19,6 @@ import java.util.Map;
 @Mapper
 public interface AccommodationReviewMapper {
 
-    /** 후기 목록 조회 (페이징) */
-    List<AccommodationReviewDTO> selectReviewList(
-            @Param("accommodationNo") int accommodationNo,
-            @Param("offset") int offset,
-            @Param("limit") int limit);
-
     /** 후기 목록 + 이미지 통합 조회 (N+1 제거) */
     List<AccommodationReviewDTO> selectReviewListWithImages(
             @Param("accommodationNo") int accommodationNo,
@@ -42,9 +36,6 @@ public interface AccommodationReviewMapper {
 
     /** 후기 이미지 등록 */
     int insertReviewImage(ReviewImageDTO dto);
-
-    /** 후기 이미지 목록 조회 */
-    List<ReviewImageDTO> selectReviewImages(@Param("reviewNo") int reviewNo);
 
     /** 후기 삭제 (본인) */
     int deleteReview(@Param("reviewNo") int reviewNo, @Param("memberNo") int memberNo);

--- a/finalProject/backend/src/main/java/edu/kh/project/accommodation/service/AccommodationServiceImpl.java
+++ b/finalProject/backend/src/main/java/edu/kh/project/accommodation/service/AccommodationServiceImpl.java
@@ -15,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import edu.kh.project.accommodation.dto.AccommodationDTO;
 import edu.kh.project.accommodation.mapper.AccommodationMapper;
+import edu.kh.project.common.service.ViewCountAsyncService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -35,6 +36,7 @@ public class AccommodationServiceImpl implements AccommodationService {
 
     private final AccommodationMapper accommodationMapper;
     private final RuralApiService ruralApiService;
+    private final ViewCountAsyncService viewCountAsyncService;
 
     @Qualifier("tourApiExecutor")
     private final Executor tourApiExecutor;
@@ -320,10 +322,10 @@ public class AccommodationServiceImpl implements AccommodationService {
     }
 
     @Override
-    @Transactional
+    @Transactional(readOnly = true)
     public AccommodationDTO getAccommodationDetail(long accommodationNo) {
-        // 조회수 증가
-        accommodationMapper.incrementViewCount(accommodationNo);
+        // 조회수 증가는 별도 트랜잭션/스레드에서 비동기 처리 (응답 시간에서 제외)
+        viewCountAsyncService.incrementAccommodationViewCount(accommodationNo);
 
         AccommodationDTO dto = accommodationMapper.selectAccommodationByNo(accommodationNo);
         if (dto != null && dto.getImageUrlsRaw() != null && !dto.getImageUrlsRaw().isEmpty()) {

--- a/finalProject/backend/src/main/java/edu/kh/project/activity/service/ActivityServiceImpl.java
+++ b/finalProject/backend/src/main/java/edu/kh/project/activity/service/ActivityServiceImpl.java
@@ -11,9 +11,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import edu.kh.project.freeboard.dto.CommentDTO;
 import edu.kh.project.activity.dto.ActivityDTO;
 import edu.kh.project.activity.mapper.ActivityMapper;
+import edu.kh.project.common.service.ViewCountAsyncService;
+import edu.kh.project.freeboard.dto.CommentDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -32,6 +33,7 @@ import lombok.extern.slf4j.Slf4j;
 public class ActivityServiceImpl implements ActivityService {
 
     private final ActivityMapper activityMapper;
+    private final ViewCountAsyncService viewCountAsyncService;
 
     @Override
     @Transactional(readOnly = true)
@@ -47,8 +49,10 @@ public class ActivityServiceImpl implements ActivityService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public ActivityDTO getActivityDetail(int boardNo, int memberNo) {
-        activityMapper.updateReadCount(boardNo);
+        // 조회수 증가는 별도 트랜잭션/스레드에서 비동기 처리
+        viewCountAsyncService.incrementActivityViewCount(boardNo);
 
         ActivityDTO board = activityMapper.selectActivityDetail(boardNo, memberNo);
 

--- a/finalProject/backend/src/main/java/edu/kh/project/common/config/AsyncConfig.java
+++ b/finalProject/backend/src/main/java/edu/kh/project/common/config/AsyncConfig.java
@@ -21,4 +21,19 @@ public class AsyncConfig {
         executor.initialize();
         return executor;
     }
+
+    /**
+     * 조회수 증가 전용 Executor (fire-and-forget UPDATE)
+     * 큐가 가득 차면 호출 스레드에서 직접 실행해 데이터 누락 방지(CallerRunsPolicy 기본).
+     */
+    @Bean(name = "viewCountExecutor")
+    public Executor viewCountExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(4);
+        executor.setQueueCapacity(500);
+        executor.setThreadNamePrefix("view-count-");
+        executor.initialize();
+        return executor;
+    }
 }

--- a/finalProject/backend/src/main/java/edu/kh/project/common/service/ViewCountAsyncService.java
+++ b/finalProject/backend/src/main/java/edu/kh/project/common/service/ViewCountAsyncService.java
@@ -1,0 +1,73 @@
+package edu.kh.project.common.service;
+
+import edu.kh.project.accommodation.mapper.AccommodationMapper;
+import edu.kh.project.activity.mapper.ActivityMapper;
+import edu.kh.project.freeboard.mapper.FreeBoardMapper;
+import edu.kh.project.notice.mapper.NoticeMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 조회수 증가 비동기 처리 서비스
+ *
+ * <p>상세 조회 시 발생하는 {@code UPDATE ... SET VIEW_COUNT = VIEW_COUNT + 1} 쿼리를
+ * 메인 응답 트랜잭션에서 분리한다. fire-and-forget 형태로 별도 스레드 풀에서 실행되어
+ * 사용자 응답 시간에 UPDATE/row lock 비용이 포함되지 않는다.</p>
+ *
+ * <p>@Async self-invocation 문제를 피하기 위해 호출 측 서비스와 분리된 빈으로 구성.
+ * REQUIRES_NEW 트랜잭션으로 호출자의 readOnly 트랜잭션과 격리된다.</p>
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ViewCountAsyncService {
+
+    private final AccommodationMapper accommodationMapper;
+    private final FreeBoardMapper freeBoardMapper;
+    private final ActivityMapper activityMapper;
+    private final NoticeMapper noticeMapper;
+
+    @Async("viewCountExecutor")
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void incrementAccommodationViewCount(long accommodationNo) {
+        try {
+            accommodationMapper.incrementViewCount(accommodationNo);
+        } catch (Exception e) {
+            log.warn("숙소 조회수 증가 실패 - accommodationNo: {}", accommodationNo, e);
+        }
+    }
+
+    @Async("viewCountExecutor")
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void incrementFreeBoardViewCount(int boardNo) {
+        try {
+            freeBoardMapper.updateReadCount(boardNo);
+        } catch (Exception e) {
+            log.warn("자유게시판 조회수 증가 실패 - boardNo: {}", boardNo, e);
+        }
+    }
+
+    @Async("viewCountExecutor")
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void incrementActivityViewCount(int boardNo) {
+        try {
+            activityMapper.updateReadCount(boardNo);
+        } catch (Exception e) {
+            log.warn("활동 게시판 조회수 증가 실패 - boardNo: {}", boardNo, e);
+        }
+    }
+
+    @Async("viewCountExecutor")
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void incrementNoticeViewCount(int boardNo) {
+        try {
+            noticeMapper.updateReadCount(boardNo);
+        } catch (Exception e) {
+            log.warn("공지사항 조회수 증가 실패 - boardNo: {}", boardNo, e);
+        }
+    }
+}

--- a/finalProject/backend/src/main/java/edu/kh/project/freeboard/service/FreeBoardServiceImpl.java
+++ b/finalProject/backend/src/main/java/edu/kh/project/freeboard/service/FreeBoardServiceImpl.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import edu.kh.project.common.service.ViewCountAsyncService;
 import edu.kh.project.freeboard.dto.CommentDTO;
 import edu.kh.project.freeboard.dto.FreeBoardDTO;
 import edu.kh.project.freeboard.mapper.FreeBoardMapper;
@@ -32,6 +33,7 @@ import lombok.extern.slf4j.Slf4j;
 public class FreeBoardServiceImpl implements FreeBoardService {
 
     private final FreeBoardMapper freeBoardMapper;
+    private final ViewCountAsyncService viewCountAsyncService;
 
     @Override
     @Transactional(readOnly = true)
@@ -47,8 +49,10 @@ public class FreeBoardServiceImpl implements FreeBoardService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public FreeBoardDTO getFreeBoardDetail(int boardNo, int memberNo) {
-        freeBoardMapper.updateReadCount(boardNo);
+        // 조회수 증가는 별도 트랜잭션/스레드에서 비동기 처리
+        viewCountAsyncService.incrementFreeBoardViewCount(boardNo);
 
         FreeBoardDTO board = freeBoardMapper.selectFreeBoardDetail(boardNo, memberNo);
 

--- a/finalProject/backend/src/main/java/edu/kh/project/notice/service/NoticeServiceImpl.java
+++ b/finalProject/backend/src/main/java/edu/kh/project/notice/service/NoticeServiceImpl.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import edu.kh.project.common.service.ViewCountAsyncService;
 import edu.kh.project.notice.dto.NoticeDTO;
 import edu.kh.project.notice.mapper.NoticeMapper;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 public class NoticeServiceImpl implements NoticeService {
 
     private final NoticeMapper noticeMapper;
+    private final ViewCountAsyncService viewCountAsyncService;
 
     @Override
     @Transactional(readOnly = true)
@@ -40,9 +42,10 @@ public class NoticeServiceImpl implements NoticeService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public NoticeDTO getNoticeDetail(int boardNo) {
-        // 조회수 증가
-        noticeMapper.updateReadCount(boardNo);
+        // 조회수 증가는 별도 트랜잭션/스레드에서 비동기 처리
+        viewCountAsyncService.incrementNoticeViewCount(boardNo);
         return noticeMapper.selectNoticeDetail(boardNo);
     }
 

--- a/finalProject/backend/src/main/resources/mappers/accommodation-review-mapper.xml
+++ b/finalProject/backend/src/main/resources/mappers/accommodation-review-mapper.xml
@@ -2,22 +2,6 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="edu.kh.project.accommodation.mapper.AccommodationReviewMapper">
 
-    <resultMap id="reviewResultMap" type="edu.kh.project.accommodation.dto.AccommodationReviewDTO">
-        <id property="reviewNo" column="REVIEW_NO" />
-        <result property="accommodationNo" column="ACCOMMODATION_NO" />
-        <result property="memberNo" column="MEMBER_NO" />
-        <result property="rating" column="RATING" />
-        <result property="content" column="CONTENT" />
-        <result property="checkInDate" column="CHECK_IN_DATE" />
-        <result property="checkOutDate" column="CHECK_OUT_DATE" />
-        <result property="recommendedFor" column="RECOMMENDED_FOR" />
-        <result property="status" column="STATUS" />
-        <result property="createdAt" column="CREATED_AT" />
-        <result property="authorNickname" column="NICKNAME" />
-        <result property="authorProfileImg" column="PROFILE_IMAGE" />
-        <result property="verifiedReviewer" column="VERIFIED_REVIEWER" />
-    </resultMap>
-
     <!-- 후기 + 이미지 통합 ResultMap (N+1 제거) -->
     <resultMap id="reviewWithImagesResultMap" type="edu.kh.project.accommodation.dto.AccommodationReviewDTO">
         <id property="reviewNo" column="REVIEW_NO" />
@@ -41,15 +25,6 @@
             <result property="renamedName" column="RENAMED_NAME" />
             <result property="imageOrder" column="IMAGE_ORDER" />
         </collection>
-    </resultMap>
-
-    <resultMap id="reviewImageResultMap" type="edu.kh.project.accommodation.dto.ReviewImageDTO">
-        <id property="imageNo" column="IMAGE_NO" />
-        <result property="reviewNo" column="REVIEW_NO" />
-        <result property="imageUrl" column="IMAGE_URL" />
-        <result property="originalName" column="ORIGINAL_NAME" />
-        <result property="renamedName" column="RENAMED_NAME" />
-        <result property="imageOrder" column="IMAGE_ORDER" />
     </resultMap>
 
     <!-- 후기 목록 + 이미지 통합 조회 (N+1 제거) -->
@@ -102,32 +77,6 @@
         ORDER BY P.RN, I.IMAGE_ORDER
     </select>
 
-    <!-- 후기 목록 (숙소별, 페이징) - 기존 호환용 -->
-    <select id="selectReviewList" resultMap="reviewResultMap">
-        SELECT * FROM (
-            SELECT
-                R.REVIEW_NO,
-                R.ACCOMMODATION_NO,
-                R.MEMBER_NO,
-                R.RATING,
-                R.CONTENT,
-                TO_CHAR(R.CHECK_IN_DATE, 'YYYY-MM-DD') AS CHECK_IN_DATE,
-                TO_CHAR(R.CHECK_OUT_DATE, 'YYYY-MM-DD') AS CHECK_OUT_DATE,
-                R.RECOMMENDED_FOR,
-                R.STATUS,
-                TO_CHAR(R.CREATED_AT, 'YYYY-MM-DD') AS CREATED_AT,
-                M.NICKNAME,
-                M.PROFILE_IMAGE,
-                M.VERIFIED_REVIEWER,
-                ROW_NUMBER() OVER (ORDER BY R.CREATED_AT DESC) AS RN
-            FROM ACCOMMODATION_REVIEW R
-            JOIN MEMBER M ON R.MEMBER_NO = M.MEMBER_NO
-            WHERE R.ACCOMMODATION_NO = #{accommodationNo}
-              AND R.STATUS = 'A'
-        )
-        WHERE RN BETWEEN #{offset} + 1 AND #{offset} + #{limit}
-    </select>
-
     <!-- 후기 건수 -->
     <select id="selectReviewCount" resultType="int">
         SELECT COUNT(*)
@@ -169,14 +118,6 @@
             SEQ_REVIEW_IMG_NO.NEXTVAL, #{reviewNo}, #{imageUrl}, #{originalName}, #{renamedName}, #{imageOrder}
         )
     </insert>
-
-    <!-- 후기 이미지 목록 -->
-    <select id="selectReviewImages" resultMap="reviewImageResultMap">
-        SELECT IMAGE_NO, REVIEW_NO, IMAGE_URL, ORIGINAL_NAME, RENAMED_NAME, IMAGE_ORDER
-        FROM REVIEW_IMAGE
-        WHERE REVIEW_NO = #{reviewNo}
-        ORDER BY IMAGE_ORDER
-    </select>
 
     <!-- 후기 삭제 (본인) -->
     <update id="deleteReview">


### PR DESCRIPTION
## 배경

상세 조회마다 \`UPDATE ... SET VIEW_COUNT = VIEW_COUNT + 1\` 쿼리가 메인 응답 트랜잭션 안에서 동기로 실행되고 있었음. 동시 조회 시:
- 같은 row에 대한 lock 경합으로 응답 시간이 흔들림
- 메인 트랜잭션을 readOnly로 만들 수 없어 추가 최적화도 막힘
- DB UPDATE가 사용자 응답 시간에 그대로 가산됨

조회수는 fire-and-forget이 적절한 작업이므로 **별도 스레드 풀에서 비동기로 분리**.

부수적으로, 숙소 후기 매퍼의 미사용 코드(\`selectReviewList\`, \`selectReviewImages\`, 관련 ResultMap 2개)도 제거 — \`selectReviewListWithImages\`로 이미 N+1이 해결되어 있어 이전 호환용 매퍼는 dead code.

development에서 검증 완료 → main으로 승격.

## 변경 사항

### 1) 조회수 비동기 처리 (#4)

**신규 파일:** \`backend/src/main/java/edu/kh/project/common/service/ViewCountAsyncService.java\`
- \`@Async("viewCountExecutor")\` + \`@Transactional(propagation = REQUIRES_NEW)\`로 호출자 트랜잭션과 격리
- 도메인별 메서드 4개: \`incrementAccommodationViewCount\`, \`incrementFreeBoardViewCount\`, \`incrementActivityViewCount\`, \`incrementNoticeViewCount\`
- 각 메서드는 try/catch로 실패 시에도 사용자 요청에 영향 없도록 처리(warn 로그)

**Executor 추가:** \`AsyncConfig.viewCountExecutor\`
\`\`\`java
core 2 / max 4 / queue 500 / thread prefix "view-count-"
\`\`\`
큐가 가득 차면 기본 \`CallerRunsPolicy\`로 호출 스레드에서 실행되어 카운트 누락 없음.

**호출 측 변경 (4개 서비스):**
| 파일 | 변경 |
|---|---|
| \`AccommodationServiceImpl.getAccommodationDetail\` | \`@Transactional\` → \`@Transactional(readOnly = true)\` + 비동기 호출 |
| \`FreeBoardServiceImpl.getFreeBoardDetail\` | \`@Transactional(readOnly = true)\` 명시 + 비동기 호출 |
| \`ActivityServiceImpl.getActivityDetail\` | 동일 |
| \`NoticeServiceImpl.getNoticeDetail\` | 동일 |

\`@Async\` self-invocation 함정을 피하기 위해 별도 빈으로 분리. 호출자 트랜잭션과 분리되도록 \`REQUIRES_NEW\`.

### 2) 후기 매퍼 dead code 제거 (#3)

\`AccommodationReviewMapper.java\`:
- \`selectReviewList(int, int, int)\` 메서드 제거 (어디서도 호출되지 않음)
- \`selectReviewImages(int)\` 메서드 제거 (동일)

\`accommodation-review-mapper.xml\`:
- \`<select id="selectReviewList">\` 제거
- \`<select id="selectReviewImages">\` 제거
- 미사용 \`reviewResultMap\`, \`reviewImageResultMap\` 제거 (\`reviewWithImagesResultMap\`만 남음)

서비스는 이미 \`selectReviewListWithImages\`만 사용 중이라 동작 변경 없음.

## 영향 범위

### 응답 시간
- 숙소/게시글/공지 상세 조회 응답 시간에서 UPDATE 비용 + row lock 대기 시간 제거
- 메인 트랜잭션이 \`readOnly\` 가 되어 connection pool 효율도 개선

### 정확성
- \`UPDATE ... = ... + 1\`은 SQL 레벨에서 atomic이라 lost update 없음
- REQUIRES_NEW로 별도 트랜잭션이라 메인 응답이 실패해도 카운트 정상 반영
- 큐 초과 시 \`CallerRunsPolicy\`로 호출 스레드 fallback → 카운트 누락 0

### 호환성
- DTO/응답 스키마 변동 없음 → 프론트 변경 불필요
- 스키마 변경 없음 → 마이그레이션 불필요

## 검증

- \`./gradlew compileJava\` 성공
- development 브랜치에서 스모크 테스트 완료
- \`@Async\` 빈 self-invocation 회피 (별도 \`ViewCountAsyncService\` 빈 호출)
- \`@EnableAsync\`는 기존 \`AsyncConfig\`에 이미 활성화되어 있음

## 배포 절차 (운영)

1. 코드 배포 (재시작)
2. 로그에서 \`view-count-\` 스레드가 정상 기동되는지 확인
3. 동일 게시글 동시 새로고침 시 \`VIEW_COUNT\`가 정확히 N만큼 증가하는지 확인

## 롤백

본 PR revert로 끝. 신규 빈/메서드만 추가됐고 schema 변경 없음.

## 관련 PR

- #36 (Dev_CCL → development) ← 본 변경의 원본